### PR TITLE
Fix half-duplex pin initialization problems in begin()

### DIFF
--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -266,7 +266,11 @@ void SoftwareSerial::begin(long speed) {
   #endif
   _speed = speed;
   if (!initialised) {
-    HAL_softSerial_init();   
+    HAL_softSerial_init();
+
+    // Set output pin as input, to ensure GPIO clock is started before calling setTX().
+    pinMode(_transmitPin, _inverse_logic ? INPUT_PULLDOWN : INPUT_PULLUP);
+
     initialised = true;
   }
   if (!_half_duplex) {

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -267,12 +267,12 @@ void SoftwareSerial::begin(long speed) {
   _speed = speed;
   if (!initialised) {
     HAL_softSerial_init();
-
-    // Set output pin as input, to ensure GPIO clock is started before calling setTX().
-    pinMode(_transmitPin, _inverse_logic ? INPUT_PULLDOWN : INPUT_PULLUP);
-
     initialised = true;
   }
+
+  // Set output pin as input, to ensure GPIO clock is started before calling setTX().
+  pinMode(_transmitPin, _inverse_logic ? INPUT_PULLDOWN : INPUT_PULLUP);
+
   if (!_half_duplex) {
     setTX();
     setRX();

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -276,11 +276,11 @@ void SoftwareSerial::begin(long speed) {
   if (!_half_duplex) {
     setTX();
     setRX();
+    listen();
   }
   else
     setTX();  
   
-  listen();
   //printf("hd %d active_in %d tx %d rx %d\n", _half_duplex, active_in, _receivePin, _transmitPin);
 }
 


### PR DESCRIPTION
I observed that some TX pins were initialized to the wrong logic level, preventing a TMCStepper driver from seeing the start bit. As a result, the first register write was ignored the the driver misconfigured.

I found this was caused by the GPIO port clock not yet being started prior to the call to setTX. This was on a STM32F4 processor, where nothing had happened to use a GPIO pin on that port prior to SoftwareSerial initialization. The GPIO clock is not started until the first call to pinMode.

By initializing the pin as an input, the GPIO clock will be started, and the initial value is applied correctly in setTX().

TX pin output prior to change. Captured on first transmit after board reset:
![Before_Cropped](https://user-images.githubusercontent.com/20053467/68090710-d01b2700-fe2b-11e9-88f8-2b1f8c5cf08e.PNG)

TX pin output after change. Captured on first transmit after board reset:
![After_Cropped](https://user-images.githubusercontent.com/20053467/68090713-dad5bc00-fe2b-11e9-8fb3-7d9eada70c7c.PNG)
